### PR TITLE
Fix occasional segfault when encoding shm buffers

### DIFF
--- a/compositor-proxy/native/src/encoder.h
+++ b/compositor-proxy/native/src/encoder.h
@@ -15,6 +15,45 @@ struct encoded_frame {
     uint32_t size;
 };
 
+enum frame_buffer_type {
+    SHM,
+    DMA,
+};
+
+union frame_buffer {
+    struct {
+        enum frame_buffer_type type;
+        uint32_t buffer_id;
+
+        void (*discard_cb)(const union frame_buffer *frame_buffer);
+    } base;
+
+    struct {
+        enum frame_buffer_type type;
+        uint32_t buffer_id;
+
+        void (*discard_cb)(const union frame_buffer *frame_buffer);
+
+        uint32_t width;
+        uint32_t height;
+        enum wl_shm_format buffer_format;
+        void *buffer_data;
+        uint32_t buffer_stride;
+        struct wl_shm_pool *pool;
+    } shm;
+
+    struct {
+        enum frame_buffer_type type;
+        uint32_t buffer_id;
+
+        void (*discard_cb)(const union frame_buffer *frame_buffer);
+
+        uint32_t width;
+        uint32_t height;
+        struct dmabuf_attributes *attributes;
+    } dma;
+};
+
 typedef void (*frame_callback_func)(void *user_data, struct encoded_frame *encoded_frame);
 
 struct encoder;
@@ -24,7 +63,8 @@ frame_encoder_create(char preferred_frame_encoder[16], frame_callback_func frame
                      struct frame_encoder **frame_encoder_pp, struct westfield_egl *westfield_egl);
 
 int
-frame_encoder_encode(struct frame_encoder **frame_encoder_pp, struct wl_resource *buffer_resource, uint32_t buffer_content_serial,
+frame_encoder_encode(struct frame_encoder **frame_encoder_pp, const union frame_buffer *frame_buffer,
+                     uint32_t buffer_content_serial,
                      uint32_t buffer_creation_serial);
 
 int

--- a/compositor-proxy/native/src/gst_main_loop.c
+++ b/compositor-proxy/native/src/gst_main_loop.c
@@ -12,7 +12,8 @@ do_gst_frame_encoder_create(char preferred_frame_encoder[16], frame_callback_fun
                             struct frame_encoder **frame_encoder_pp, struct westfield_egl *westfield_egl);
 
 extern void
-do_gst_frame_encoder_encode(struct frame_encoder **frame_encoder_pp, struct wl_resource *buffer_resource, uint32_t buffer_content_serial,
+do_gst_frame_encoder_encode(struct frame_encoder **frame_encoder_pp, const union frame_buffer *frame_buffer,
+                            uint32_t buffer_content_serial,
                             uint32_t buffer_creation_serial);
 
 extern void
@@ -50,7 +51,7 @@ struct gf_message {
         } frame_encoder_create;
         struct {
             struct frame_encoder **frame_encoder_pp;
-            struct wl_resource *buffer_resource;
+            const union frame_buffer *frame_buffer;
             uint32_t buffer_content_serial;
             uint32_t buffer_creation_serial;
         } frame_encoder_encode;
@@ -161,7 +162,7 @@ main_loop_handle_message(struct gf_message *message) {
             break;
         case frame_encoder_encode_type:
             do_gst_frame_encoder_encode(message->body.frame_encoder_encode.frame_encoder_pp,
-                                        message->body.frame_encoder_encode.buffer_resource,
+                                        message->body.frame_encoder_encode.frame_buffer,
                                         message->body.frame_encoder_encode.buffer_content_serial,
                                         message->body.frame_encoder_encode.buffer_creation_serial
             );
@@ -230,13 +231,14 @@ frame_encoder_create(char preferred_frame_encoder[16],
 }
 
 int
-frame_encoder_encode(struct frame_encoder **frame_encoder_pp, struct wl_resource *buffer_resource, uint32_t buffer_content_serial,
+frame_encoder_encode(struct frame_encoder **frame_encoder_pp, const union frame_buffer *frame_buffer,
+                     uint32_t buffer_content_serial,
                      uint32_t buffer_creation_serial) {
     struct gf_message *message = g_new0(struct gf_message, 1);
 
     message->type = frame_encoder_encode_type;
     message->body.frame_encoder_encode.frame_encoder_pp = frame_encoder_pp;
-    message->body.frame_encoder_encode.buffer_resource = buffer_resource;
+    message->body.frame_encoder_encode.frame_buffer = frame_buffer;
     message->body.frame_encoder_encode.buffer_content_serial = buffer_content_serial;
     message->body.frame_encoder_encode.buffer_creation_serial = buffer_creation_serial;
 


### PR DESCRIPTION
- Do all wayland server specific calls in nodejs thread
- Make sure we don't free shm memory too early