### PR TITLE
fix: clone over https

### DIFF
--- a/libs/compositor-ffmpeg-h264/build_wasm.sh
+++ b/libs/compositor-ffmpeg-h264/build_wasm.sh
@@ -11,7 +11,7 @@ popd
 
 FFMPEG_VERSION="n5.1.2"
 ensure_ffmpeg() {
-  [ -e ffmpeg ] || git clone --depth 1 --branch "$FFMPEG_VERSION" "git@github.com:FFmpeg/FFmpeg.git" ffmpeg
+  [ -e ffmpeg ] || git clone --depth 1 --branch "$FFMPEG_VERSION" "https://github.com/FFmpeg/FFmpeg.git" ffmpeg
 }
 
 build() {


### PR DESCRIPTION
Fix: use `https` to clone `ffmpeg` repo

Description:

Current `libs/compositor-ffmpeg-h264/build_wasm.sh` script uses `ssh` to `git clone` repo for `ffmpeg`.

However, many people (like me) building may be using a build environment without GitHub ssh setup. Attempting to clone GitHub repo without ssh keys setup results in the following error:

```bash
Cloning into 'ffmpeg'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

btw, I'm sorry to be opening such a pedantic PR, as I really appreciate all your hard work and think it's very cool what you're doing.