### PR TITLE
Fix typo in code snippet

### DIFF
--- a/docs/pages/design/index.md
+++ b/docs/pages/design/index.md
@@ -181,7 +181,7 @@ Compositor Proxy CLI.
 
 ```shell
 export XAUTHORITY=.Xauthority
-touch "$HOME/$XAUTHORITY"`
+touch "$HOME/$XAUTHORITY"
 xauth add "${HOST}":1 . "$(xxd -l 16 -p /dev/urandom)"
 ````
 


### PR DESCRIPTION
I copy-pasted these commands and was momentarily confused why the command was hanging. Turns out there was an erroneous backtick!